### PR TITLE
Fix Timing Logic in Signal Generation Runner

### DIFF
--- a/src/apollo/core/signal_generation_runner.py
+++ b/src/apollo/core/signal_generation_runner.py
@@ -47,7 +47,7 @@ class SignalGenerationRunner:
     def run_signal_generation(self) -> None:
         """Run signal generation process."""
 
-        while self._running:
+        while True:
             # Get current point in time
             # in the configured exchange
             current_datetime_in_exchange = datetime.now(
@@ -130,11 +130,12 @@ class SignalGenerationRunner:
 
                 logger.info("Signal generation process completed.")
 
-            # Flip back after market
-            # open on a business, non-holiday day
+            # Flip back after market open,
+            # but before close, on a business, non-holiday day
             if (
                 is_business_day
                 and not is_market_holiday
                 and current_datetime_in_exchange.time() >= open_time_in_exchange
+                and current_datetime_in_exchange.time() < close_time_in_exchange
             ):
                 self._running = True


### PR DESCRIPTION
* Make while condition independent from running condition.

* Improve the control logic that flips the running switch.